### PR TITLE
WAR-12: Implement editable form functionality for table cells

### DIFF
--- a/docs/editable-table/element.mjs
+++ b/docs/editable-table/element.mjs
@@ -94,6 +94,9 @@ export class EditableTable extends HTMLElement {
                     // Clone the template element
                     const input = templateElement.cloneNode(true);
                     
+                    // Convert editable text spans to input elements
+                    this.convertEditableTextToInput(input);
+                    
                     // Generate unique name for persistence
                     const fieldName = `table-${this.tableId}-row-${rowIndex}-col-${colIndex}`;
                     this.setFieldName(input, fieldName);
@@ -107,6 +110,48 @@ export class EditableTable extends HTMLElement {
                 }
             }
         });
+    }
+
+    convertEditableTextToInput(element) {
+        // If the element itself has the editable text class, convert it
+        if (element.classList && element.classList.contains('table-editable-text')) {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = element.className;
+            
+            // Copy any existing attributes except class
+            for (const attr of element.attributes) {
+                if (attr.name !== 'class' && attr.name !== 'data-slot') {
+                    input.setAttribute(attr.name, attr.value);
+                }
+            }
+            
+            // Replace the element with the input
+            if (element.parentNode) {
+                element.parentNode.replaceChild(input, element);
+            }
+            return input;
+        }
+        
+        // Find and convert any child elements with editable text class
+        const editableElements = element.querySelectorAll('.table-editable-text');
+        editableElements.forEach(editableEl => {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = editableEl.className;
+            
+            // Copy any existing attributes except class
+            for (const attr of editableEl.attributes) {
+                if (attr.name !== 'class' && attr.name !== 'data-slot') {
+                    input.setAttribute(attr.name, attr.value);
+                }
+            }
+            
+            // Replace the element with the input
+            editableEl.parentNode.replaceChild(input, editableEl);
+        });
+        
+        return element;
     }
 
     setFieldName(element, baseName) {
@@ -154,6 +199,9 @@ export class EditableTable extends HTMLElement {
         this.templateRecordElements.forEach((templateElement, colIndex) => {
             const cell = document.createElement("td");
             const clonedContent = templateElement.cloneNode(true);
+            
+            // Convert editable text spans to input elements
+            this.convertEditableTextToInput(clonedContent);
             
             // Generate unique name for persistence
             const fieldName = `table-${this.tableId}-row-${this.rowCounter}-col-${colIndex}`;


### PR DESCRIPTION
## Summary
- Implemented functionality to convert spans with `table-editable-text` class into actual input elements
- Added `convertEditableTextToInput` method to handle the conversion process
- Updated both `makeRowEditable` and `addListItem` methods to apply the conversion
- Cells defined as editable text now render as editable input fields instead of empty spans

## Changes Made
- **New Method**: `convertEditableTextToInput()` - Converts spans with `table-editable-text` class to input elements
- **Updated**: `makeRowEditable()` - Now converts template elements before cloning
- **Updated**: `addListItem()` - Now converts editable text in newly added rows
- **Preserved**: All existing persistence and form handling functionality

## Test Plan
- [x] Verify JavaScript syntax is valid
- [x] Test that spans with `table-editable-text` class are converted to input elements
- [x] Verify that the conversion preserves existing attributes (except class and data-slot)
- [x] Ensure persistence functionality still works correctly
- [x] Test both template row conversion and new row addition
- [x] Verify no console.log statements or sensitive information in code
- [x] Confirm no temporary files created

## Technical Details
The implementation checks if an element has the `table-editable-text` class and creates a new input element with the same attributes (excluding class and data-slot). It handles both direct element conversion and nested element conversion within the cloned template content.

🤖 Generated with [Claude Code](https://claude.ai/code)