### PR TITLE
WAR-12: Add editable text cell functionality to table component

### DIFF
--- a/docs/editable-table/element.mjs
+++ b/docs/editable-table/element.mjs
@@ -91,8 +91,18 @@ export class EditableTable extends HTMLElement {
                 const templateElement = this.templateRecordElements[templateElementIndex];
                 
                 if (templateElement) {
-                    // Clone the template element
-                    const input = templateElement.cloneNode(true);
+                    let input;
+                    
+                    // Check if this is a table-editable-text element
+                    if (templateElement.classList.contains('table-editable-text')) {
+                        // Create a text input element
+                        input = document.createElement('input');
+                        input.type = 'text';
+                        input.placeholder = templateElement.getAttribute('placeholder') || '';
+                    } else {
+                        // Clone the template element as before
+                        input = templateElement.cloneNode(true);
+                    }
                     
                     // Generate unique name for persistence
                     const fieldName = `table-${this.tableId}-row-${rowIndex}-col-${colIndex}`;
@@ -153,7 +163,18 @@ export class EditableTable extends HTMLElement {
         // Clone each template record element from the light DOM
         this.templateRecordElements.forEach((templateElement, colIndex) => {
             const cell = document.createElement("td");
-            const clonedContent = templateElement.cloneNode(true);
+            let clonedContent;
+            
+            // Check if this is a table-editable-text element
+            if (templateElement.classList.contains('table-editable-text')) {
+                // Create a text input element
+                clonedContent = document.createElement('input');
+                clonedContent.type = 'text';
+                clonedContent.placeholder = templateElement.getAttribute('placeholder') || '';
+            } else {
+                // Clone the template element as before
+                clonedContent = templateElement.cloneNode(true);
+            }
             
             // Generate unique name for persistence
             const fieldName = `table-${this.tableId}-row-${this.rowCounter}-col-${colIndex}`;

--- a/docs/notes.html
+++ b/docs/notes.html
@@ -55,7 +55,12 @@
                         </select></span>
                         <span data-slot="template-record" class="table-editable-text"></span>
                         <span data-slot="template-record" class="table-editable-text"></span>
-                        <span data-slot="template-record"></span>
+                        <span data-slot="template-record"><select>
+                            <option value="">Choose...</option>
+                            <option value="alive">Alive</option>
+                            <option value="dead">Dead</option>
+                            <option value="unknown">Unknown</option>
+                        </select></span>
                     </editable-table>
                     <form>
                         <fieldset>


### PR DESCRIPTION
## Summary
- Implemented editable text cell functionality for the EditableTable component
- Table cells marked with `table-editable-text` class now render as text input fields
- Added placeholder support for editable text inputs
- Fixed missing select options for "Alive?" column in NPCs table

## Test plan
- [ ] Open `notes.html` in browser
- [ ] Verify that Name, Organization/Location, and Description/Notes columns render as text input fields
- [ ] Test that inputs persist data to localStorage on focusout
- [ ] Test adding new rows to verify editable text cells work correctly
- [ ] Verify that Gender, Species, and Alive? columns still render as select dropdowns

🤖 Generated with [Claude Code](https://claude.ai/code)